### PR TITLE
Update CLI arguments to use org/repo format

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ loopback-manager list
 loopback-manager scan
 
 # Manually assign IP
-loopback-manager assign myorg myrepo
+loopback-manager assign myorg/myrepo
 
 # Assign with specific IP
-loopback-manager assign myorg myrepo --ip 127.0.0.50
+loopback-manager assign myorg/myrepo --ip 127.0.0.50
 
 # Auto-assign IP to all unassigned repositories
 loopback-manager auto-assign
@@ -47,7 +47,7 @@ loopback-manager auto-assign
 loopback-manager check
 
 # Remove IP assignment
-loopback-manager remove myorg myrepo
+loopback-manager remove myorg/myrepo
 ```
 
 ## Configuration

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -40,12 +41,17 @@ var listCmd = &cobra.Command{
 }
 
 var assignCmd = &cobra.Command{
-	Use:   "assign <org> <repo>",
+	Use:   "assign <org/repo>",
 	Short: "Assign IP to repository",
-	Args:  cobra.ExactArgs(2),
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		parts := strings.SplitN(args[0], "/", 2)
+		if len(parts) != 2 {
+			fmt.Fprintf(os.Stderr, "Error: Invalid format. Use: org/repo\n")
+			os.Exit(1)
+		}
 		ip, _ := cmd.Flags().GetString("ip")
-		if err := mgr.Assign(args[0], args[1], ip); err != nil {
+		if err := mgr.Assign(parts[0], parts[1], ip); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
@@ -53,12 +59,17 @@ var assignCmd = &cobra.Command{
 }
 
 var removeCmd = &cobra.Command{
-	Use:   "remove <org> <repo>",
+	Use:   "remove <org/repo>",
 	Short: "Remove IP assignment",
 	Aliases: []string{"rm", "del"},
-	Args:  cobra.ExactArgs(2),
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := mgr.Remove(args[0], args[1]); err != nil {
+		parts := strings.SplitN(args[0], "/", 2)
+		if len(parts) != 2 {
+			fmt.Fprintf(os.Stderr, "Error: Invalid format. Use: org/repo\n")
+			os.Exit(1)
+		}
+		if err := mgr.Remove(parts[0], parts[1]); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}


### PR DESCRIPTION
## Summary
- Changed command syntax from `org repo` to `org/repo` to align with gh command style
- Makes the CLI more intuitive for users familiar with GitHub CLI tools

## Changes
- Updated `assign` command to accept `org/repo` format instead of separate arguments
- Updated `remove` command to accept `org/repo` format instead of separate arguments  
- Added parsing logic to split the org/repo string
- Updated README documentation with new command examples

## Test plan
- [ ] Test `loopback-manager assign myorg/myrepo` command
- [ ] Test `loopback-manager assign myorg/myrepo --ip 127.0.0.50` with specific IP
- [ ] Test `loopback-manager remove myorg/myrepo` command
- [ ] Verify error handling for invalid formats (e.g., missing slash)

🤖 Generated with [Claude Code](https://claude.ai/code)