### PR TITLE
Add dry-run mode as default for auto-assign command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,11 @@ loopback-manager assign myorg/myrepo
 # Assign with specific IP
 loopback-manager assign myorg/myrepo --ip 127.0.0.50
 
-# Auto-assign IP to all unassigned repositories
+# Auto-assign IP to all unassigned repositories (dry-run by default)
 loopback-manager auto-assign
+
+# Execute the auto-assignment (actually make changes)
+loopback-manager auto-assign --execute
 
 # Check for duplicates
 loopback-manager check

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,10 +89,11 @@ var scanCmd = &cobra.Command{
 
 var autoAssignCmd = &cobra.Command{
 	Use:   "auto-assign",
-	Short: "Auto-assign IPs to all unassigned repositories",
+	Short: "Auto-assign IPs to all unassigned repositories (dry-run by default)",
 	Aliases: []string{"auto"},
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := mgr.AutoAssign(); err != nil {
+		execute, _ := cmd.Flags().GetBool("execute")
+		if err := mgr.AutoAssign(execute); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
@@ -124,6 +125,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.config/loopback-manager/config.yaml)")
 	
 	assignCmd.Flags().StringP("ip", "i", "", "Specific IP address to assign")
+	autoAssignCmd.Flags().BoolP("execute", "e", false, "Execute the assignments (without this flag, only shows what would be done)")
 	
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(assignCmd)


### PR DESCRIPTION
## Summary
Makes auto-assign safer by defaulting to dry-run mode, requiring explicit `--execute` flag to make changes.

## Changes
- Modified `auto-assign` command to run in dry-run mode by default
- Added `--execute` / `-e` flag to actually perform assignments
- Updated manager's AutoAssign method to support dry-run mode
- Shows preview of what would be assigned without making changes
- Updated README documentation with new usage

## Why This Change?
Running auto-assign could accidentally assign IPs to many repositories at once. Making dry-run the default prevents accidental changes and lets users preview what will happen first.

## Usage
```bash
# Preview what would be assigned (dry-run)
loopback-manager auto-assign

# Actually perform the assignments
loopback-manager auto-assign --execute
```

## Test plan
- [ ] Run `loopback-manager auto-assign` without flag - should show dry-run output
- [ ] Run `loopback-manager auto-assign --execute` - should actually assign IPs
- [ ] Verify dry-run shows correct IP assignments without making changes
- [ ] Verify execute mode creates/updates .env files

🤖 Generated with [Claude Code](https://claude.ai/code)