### PR TITLE
Add host loopback address sync checking functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,50 @@ loopback-manager check
 
 # Remove IP assignment
 loopback-manager remove myorg/myrepo
+
+# List loopback addresses configured on host
+loopback-manager host-list
+
+# List with JSON output
+loopback-manager host-list --json
+
+# Check consistency between assignments and host configuration
+loopback-manager sync-check
+```
+
+### Host Configuration Management
+
+The `sync-check` command verifies that all assigned IP addresses are configured on your host system:
+
+```bash
+# Check if assigned IPs are configured on host
+loopback-manager sync-check
+```
+
+If any assigned IPs are missing from the host configuration, the command will display:
+- List of missing IP addresses and their assigned repositories
+- NetworkManager commands (using `nmcli`) to add the addresses
+- Alternative `ip` commands for systems without NetworkManager
+
+Example output:
+```
+=== Loopback Address Consistency Check ===
+
+⚠ Found 2 assigned IP addresses not configured on host:
+
+  127.0.0.11 (assigned to org/repo1)
+  127.0.0.12 (assigned to org/repo2)
+
+=== Configuration Commands ===
+
+Using NetworkManager (if available):
+  sudo nmcli connection modify lo +ipv4.addresses 127.0.0.11/32
+  sudo nmcli connection modify lo +ipv4.addresses 127.0.0.12/32
+  sudo nmcli connection up lo
+
+Alternatively, using ip command directly:
+  sudo ip addr add 127.0.0.11/32 dev lo
+  sudo ip addr add 127.0.0.12/32 dev lo
 ```
 
 ## Configuration

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -124,6 +124,31 @@ var versionCmd = &cobra.Command{
 	},
 }
 
+var hostListCmd = &cobra.Command{
+	Use:   "host-list",
+	Short: "List loopback addresses configured on the host",
+	Aliases: []string{"host-ls"},
+	Run: func(cmd *cobra.Command, args []string) {
+		jsonOutput, _ := cmd.Flags().GetBool("json")
+		if err := mgr.ListHostLoopback(jsonOutput); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var syncCheckCmd = &cobra.Command{
+	Use:   "sync-check",
+	Short: "Check consistency between assignments and host configuration",
+	Aliases: []string{"sync"},
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := mgr.SyncCheck(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
 func getVersion() string {
 	// First, check if version was set via ldflags (e.g., from Makefile)
 	if version != "dev" {
@@ -154,6 +179,7 @@ func init() {
 	
 	listCmd.Flags().BoolP("json", "j", false, "Output in JSON format")
 	scanCmd.Flags().BoolP("json", "j", false, "Output in JSON format")
+	hostListCmd.Flags().BoolP("json", "j", false, "Output in JSON format")
 	assignCmd.Flags().StringP("ip", "i", "", "Specific IP address to assign")
 	autoAssignCmd.Flags().BoolP("execute", "e", false, "Execute the assignments (without this flag, only shows what would be done)")
 	
@@ -164,6 +190,8 @@ func init() {
 	rootCmd.AddCommand(autoAssignCmd)
 	rootCmd.AddCommand(checkCmd)
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(hostListCmd)
+	rootCmd.AddCommand(syncCheckCmd)
 }
 
 func initConfig() {

--- a/internal/network/loopback.go
+++ b/internal/network/loopback.go
@@ -1,0 +1,136 @@
+package network
+
+import (
+	"fmt"
+	"net"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+type LoopbackAddress struct {
+	Interface string `json:"interface"`
+	IP        string `json:"ip"`
+	Netmask   string `json:"netmask,omitempty"`
+}
+
+// GetHostLoopbackAddresses returns all configured loopback addresses on the host
+func GetHostLoopbackAddresses() ([]LoopbackAddress, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		return getLoopbackAddressesDarwin()
+	case "linux":
+		return getLoopbackAddressesLinux()
+	default:
+		return nil, fmt.Errorf("unsupported OS: %s", runtime.GOOS)
+	}
+}
+
+func getLoopbackAddressesDarwin() ([]LoopbackAddress, error) {
+	cmd := exec.Command("ifconfig", "lo0")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to run ifconfig: %w", err)
+	}
+
+	var addresses []LoopbackAddress
+	lines := strings.Split(string(output), "\n")
+	
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "inet ") {
+			parts := strings.Fields(line)
+			if len(parts) >= 2 {
+				ip := parts[1]
+				// Include all 127.x.x.x addresses except 127.0.0.1
+				if ip != "127.0.0.1" && strings.HasPrefix(ip, "127.") {
+					addr := LoopbackAddress{
+						Interface: "lo0",
+						IP:        ip,
+					}
+					if len(parts) >= 4 && parts[2] == "netmask" {
+						addr.Netmask = parts[3]
+					}
+					addresses = append(addresses, addr)
+				}
+			}
+		}
+	}
+	
+	return addresses, nil
+}
+
+func getLoopbackAddressesLinux() ([]LoopbackAddress, error) {
+	cmd := exec.Command("ip", "addr", "show", "lo")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to run ip command: %w", err)
+	}
+
+	var addresses []LoopbackAddress
+	lines := strings.Split(string(output), "\n")
+	
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "inet ") {
+			parts := strings.Fields(line)
+			if len(parts) >= 2 {
+				ipWithMask := parts[1]
+				ip := strings.Split(ipWithMask, "/")[0]
+				// Include all 127.x.x.x addresses except 127.0.0.1
+				if ip != "127.0.0.1" && strings.HasPrefix(ip, "127.") {
+					addresses = append(addresses, LoopbackAddress{
+						Interface: "lo",
+						IP:        ip,
+						Netmask:   ipWithMask,
+					})
+				}
+			}
+		}
+	}
+	
+	return addresses, nil
+}
+
+// IsValidLoopbackIP checks if an IP is a valid loopback address
+func IsValidLoopbackIP(ip string) bool {
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return false
+	}
+	return strings.HasPrefix(ip, "127.") && ip != "127.0.0.1"
+}
+
+// IsLoopbackConfigured checks if a specific loopback IP is configured on the host
+func IsLoopbackConfigured(ip string) (bool, error) {
+	addresses, err := GetHostLoopbackAddresses()
+	if err != nil {
+		return false, err
+	}
+	
+	for _, addr := range addresses {
+		if addr.IP == ip {
+			return true, nil
+		}
+	}
+	
+	return false, nil
+}
+
+// GenerateNmcliCommand generates an nmcli command to add a loopback address
+func GenerateNmcliCommand(ip string) string {
+	return fmt.Sprintf("sudo nmcli connection modify lo +ipv4.addresses %s/32", ip)
+}
+
+// GenerateNmcliCommands generates nmcli commands for multiple addresses
+func GenerateNmcliCommands(ips []string) []string {
+	var commands []string
+	for _, ip := range ips {
+		commands = append(commands, GenerateNmcliCommand(ip))
+	}
+	// Add the command to apply changes
+	if len(commands) > 0 {
+		commands = append(commands, "sudo nmcli connection up lo")
+	}
+	return commands
+}


### PR DESCRIPTION
## Summary
- Add commands to list and check consistency between loopback assignments and host configuration
- Provide helpful nmcli and ip commands for missing loopback addresses
- Support JSON output for scripting integration

## New Commands
- `host-list` (aliases: `host-ls`) - List loopback addresses configured on the host
- `sync-check` (aliases: `sync`) - Check consistency between assignments and host configuration

## Features
- Lists all configured loopback addresses on the host (excluding 127.0.0.1)
- Detects assigned IPs that are not configured on the host
- Generates NetworkManager (nmcli) commands for adding missing addresses
- Provides alternative ip command syntax for systems without NetworkManager
- JSON output support for host-list command

## Test Plan
- [x] Test host-list command on Linux
- [x] Test host-list with --json flag
- [x] Test sync-check with missing loopback addresses
- [x] Verify nmcli command generation
- [x] Verify ip command generation
- [x] Update README documentation

🤖 Generated with [Claude Code](https://claude.ai/code)