### PR TITLE
Fix loopback address netmask from /32 to /8

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,13 @@ Example output:
 === Configuration Commands ===
 
 Using NetworkManager (if available):
-  sudo nmcli connection modify lo +ipv4.addresses 127.0.0.11/32
-  sudo nmcli connection modify lo +ipv4.addresses 127.0.0.12/32
+  sudo nmcli connection modify lo +ipv4.addresses 127.0.0.11/8
+  sudo nmcli connection modify lo +ipv4.addresses 127.0.0.12/8
   sudo nmcli connection up lo
 
 Alternatively, using ip command directly:
-  sudo ip addr add 127.0.0.11/32 dev lo
-  sudo ip addr add 127.0.0.12/32 dev lo
+  sudo ip addr add 127.0.0.11/8 dev lo
+  sudo ip addr add 127.0.0.12/8 dev lo
 ```
 
 ## Configuration

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -500,7 +500,7 @@ func (m *Manager) SyncCheck() error {
 	
 	fmt.Println("\nAlternatively, using ip command directly:")
 	for _, ip := range missingIPs {
-		fmt.Printf("  sudo ip addr add %s/32 dev lo\n", ip)
+		fmt.Printf("  sudo ip addr add %s/8 dev lo\n", ip)
 	}
 	
 	fmt.Println("\nNote: These changes may not persist after reboot without proper configuration.")

--- a/internal/network/loopback.go
+++ b/internal/network/loopback.go
@@ -119,7 +119,7 @@ func IsLoopbackConfigured(ip string) (bool, error) {
 
 // GenerateNmcliCommand generates an nmcli command to add a loopback address
 func GenerateNmcliCommand(ip string) string {
-	return fmt.Sprintf("sudo nmcli connection modify lo +ipv4.addresses %s/32", ip)
+	return fmt.Sprintf("sudo nmcli connection modify lo +ipv4.addresses %s/8", ip)
 }
 
 // GenerateNmcliCommands generates nmcli commands for multiple addresses


### PR DESCRIPTION
## Summary
- Fix incorrect netmask for loopback addresses
- Loopback addresses belong to 127.0.0.0/8 network

## Changes
- Update nmcli command generation to use /8 instead of /32
- Update ip command examples to use /8 instead of /32  
- Update README documentation with correct netmask

## Test Plan
- [x] Build and test locally
- [x] Verify sync-check command outputs correct netmask
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)